### PR TITLE
Support Uint8(Clamped)Array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import patternTree from "./pattern-tree.snapshot";
 import { GuessedFile, Node, Tree } from "./model/tree";
 import { fromHex, toHex } from "./model/toHex";
 
-export const filetypeinfo = (bytes: number[]): GuessedFile[] => {
+export const filetypeinfo = (
+  bytes: number[] | Uint8Array | Uint8ClampedArray
+): GuessedFile[] => {
   let tree: Tree = patternTree;
   for (const k of Object.keys(tree.offset)) {
     const offset = fromHex(k);


### PR DESCRIPTION
This PR makes `filetypeinfo()` accept `Uint8Array` and `Uint8ClampedArray` as the first argument. It doesn't change any code other than the type definition.

## Rationale

Currently, the type definition of `filetypeinfo()` does not accept `Uint8Array` and `Uint8ClampedArray`:

```ts
import filetype from 'magic-bytes.js';

const buffer: ArrayBuffer = getArrayBufferFromSomewhere();
const arr = new Uint8Array(buffer);

// Type error:
// Argument of type 'Uint8Array' is not assignable to parameter of type 'number[]'
//   Type 'Uint8Array' is missing the following properties from type 'number[]': pop, push, concat, shift, and 5 more. ts(2345)
let result = filetypeinfo(arr);
```

This is because `Uint8Array` and `Uint8ClampedArray` are incompatible with `number[]`, or any regular JavaScript arrays for that matter.

However, magic-bytes.js _does_ support `Uint8Array` and `Uint8ClampedArray` just fine. When I force the program to compile, the resulting program works!

```ts
// This actually works!
let result = filetypeinfo(arr as any);
```

Since `Uint8Array` and `Uint8ClampedArray` are widely used for manipulating bytes in JS, it would be great if magic-bytes.js supported them as well.