### PR TITLE
Add mp3 signatures

### DIFF
--- a/src/model/pattern-tree.ts
+++ b/src/model/pattern-tree.ts
@@ -696,6 +696,8 @@ add(
 );
 
 add("mp3", ["0xFF", "0xFB"], { mime: "audio/mpeg", extension: "mp3" });
+add("mp3", ["0xFF", "0xF3"], { mime: "audio/mpeg", extension: "mp3" });
+add("mp3", ["0xFF", "0xF2"], { mime: "audio/mpeg", extension: "mp3" });
 add("mp3", ["0x49", "0x44", "0x33"], { mime: "audio/mpeg", extension: "mp3" });
 
 add("bmp", ["0x42", "0x4D"], { mime: "image/bmp", extension: "bmp" });


### PR DESCRIPTION
Adds an mp3 Hex signature that is not in the current code. (FF F3, FF F2)

https://en.wikipedia.org/wiki/List_of_file_signatures

![image](https://user-images.githubusercontent.com/53992007/217484338-1e65d9f7-0f1c-4edd-af1f-a88750fe19a9.png)
