### PR TITLE
Fixed incorrect method names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Using HTML:
 # API
 The following functions are availble:
 * `filetypeinfo(bytes: number[])` Contains typeinformation like name, extension and mime type: `[{typename: "zip"}, {typename: "jar"}]`
-* `filetypenames(bytes: number[])` : Contains type names only: `["zip", "jar"]`
+* `filetypename(bytes: number[])` : Contains type names only: `["zip", "jar"]`
 * `filetypemime(bytes: number[])` : Contains type mime types only: `["application/zip", "application/jar"]`
-* `filetypeextensions(bytes: number[])` : Contains type extensions only: `["zip", "jar"]`
+* `filetypeextension(bytes: number[])` : Contains type extensions only: `["zip", "jar"]`
 
 Both function return an empty array `[]` otherwise, which means it could not detect the file signature. Keep in mind that 
 txt files for example fall in this category.


### PR DESCRIPTION
I was confused by the wrong method names in the README, so I corrected them.