### PR TITLE
Fix typescript errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@commitlint/cli": "^17.7.1",
         "@commitlint/config-conventional": "^17.7.0",
         "@semantic-release/git": "^10.0.1",
-        "@types/jest": "^27.0.1",
+        "@types/jest": "^27.5.2",
         "@types/node": "^16.6.2",
         "husky": "^8.0.3",
         "jest": "^27.0.6",
@@ -3617,12 +3617,13 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
     },
@@ -17076,12 +17077,12 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "requires": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
     "@semantic-release/git": "^10.0.1",
-    "@types/jest": "^27.0.1",
+    "@types/jest": "^27.5.2",
     "@types/node": "^16.6.2",
     "husky": "^8.0.3",
     "jest": "^27.0.6",

--- a/src/model/tree.ts
+++ b/src/model/tree.ts
@@ -34,25 +34,22 @@ const createMatch = (leaf: PathlessNewNode): GuessedFile => ({
   extension: leaf.info.extension,
 });
 
-const isMatchingNode = (tree: Node, path: string[]) =>
+const isLeafNode = (tree: Node, path: string[]) =>
   tree && path.length === 0;
 
-const head = (arr: any[]) => arr[0];
-const tail = (arr: any[]) => arr.slice(1, arr.length);
 
 export const merge = (node: NewNode, tree: Node): Node => {
   if (node.bytes.length === 0) return tree;
-  const currentByte = head(node.bytes); // 0
-  const path = tail(node.bytes); // [1,2]
+  const [currentByte, ...path] = node.bytes;
 
   const currentTree: Node = tree.bytes[currentByte];
   // traversed to end. Just add key to leaf.
-  if (isMatchingNode(currentTree, path)) {
+  if (isLeafNode(currentTree, path)) {
     const matchingNode = tree.bytes[currentByte];
     tree.bytes[currentByte] = {
       ...matchingNode,
       matches: [
-        ...(matchingNode.matches ? matchingNode.matches : []),
+        ...(matchingNode.matches ?? []),
         createMatch(node),
       ],
     };
@@ -65,11 +62,7 @@ export const merge = (node: NewNode, tree: Node): Node => {
       createNode(node.typename, path, node.info),
       tree.bytes[currentByte]
     );
-    return tree;
-  }
-
-  // Tree did not exist before
-  if (!tree.bytes[currentByte]) {
+  } else { // Tree did not exist before
     tree.bytes[currentByte] = createComplexNode(node.typename, path, node.info);
   }
   return tree;
@@ -92,8 +85,7 @@ export const createComplexNode = (
     bytes: {},
     matches: undefined,
   };
-  const currentKey = head(bytes); // 0
-  const path = tail(bytes); // [1,2]
+  const [currentKey, ...path] = bytes;
   if (bytes.length === 0) {
     return {
       matches: [

--- a/src/model/tree.ts
+++ b/src/model/tree.ts
@@ -70,10 +70,7 @@ export const merge = (node: NewNode, tree: Node): Node => {
 
   // Tree did not exist before
   if (!tree.bytes[currentByte]) {
-    tree.bytes[currentByte] = {
-      ...tree.bytes[currentByte],
-      ...createComplexNode(node.typename, path, node.info),
-    };
+    tree.bytes[currentByte] = createComplexNode(node.typename, path, node.info);
   }
   return tree;
 };


### PR DESCRIPTION
Adds two small changes to fix typescript errors which were preventing the package being installed from github. I no longer need this as I can install from npm with the recent changes, but figure it's worth fixing anyway.

- Add jest types.
- Remove merging with existing path (tree.bytes[currentByte]) when existing path doesn't exist. Currently the existing path is always an empty object `{}` when reaching this path so merging with it is unnecessary. Additionally could have caused errors if the value of tree.bytes[currentByte] ended up being another non-spreadable falsey value (false, 0, '', NaN, etc)

Also tidied up the tree file slightly while I was at it. No functional changes just small readability things.